### PR TITLE
LTI Deeplinking Production Hotfix

### DIFF
--- a/src/routers/AppRouter.js
+++ b/src/routers/AppRouter.js
@@ -40,7 +40,7 @@ const PreviewPage = loadable(() => import('../containers/Preview'));
 const LtiPreviewPage = loadable(() => import('../containers/LtiPreviewPage'));
 const PreviewPageShared = loadable(() => import('../containers/PreviewPageShared'));
 const SearchResult = loadable(() => import('../containers/Search'));
-// const LtiModel = loadable(() => import('../containers/LtiModel'));
+const LtiModel = loadable(() => import('../containers/LtiModel'));
 // const TeamsPage = loadable(() => import('../containers/Teams'));
 // const AddTeamProjectsPage = loadable(() => import('../containers/Teams/AddProjects'));
 // const AddTeamProjectMemberPage = loadable(() => import('../containers/Teams/AddMembers'));
@@ -48,7 +48,7 @@ const GclassActivityPage = loadable(() => import('../containers/LMS/GoogleClassr
 const ActivityCreate = loadable(() => import('../containers/CreateActivity'));
 const EditActivity = loadable(() => import('../containers/EditActivity'));
 const GclassSummaryPage = loadable(() => import('../containers/LMS/GoogleClassroom/GclassSummaryPage'));
-const SearchPage = loadable(() => import('../containers/LMS/Canvas/DeepLinking/SearchPage'));
+// const SearchPage = loadable(() => import('../containers/LMS/Canvas/DeepLinking/SearchPage'));
 
 const AppRouter = () => {
   useEffect(() => {
@@ -188,8 +188,8 @@ const AppRouter = () => {
         <OpenRoute
           exact
           path="/lti/content/:lmsUrl/:ltiClientId/:redirectUrl"
-          // component={LtiModel}
-          component={SearchPage}
+          component={LtiModel}
+          // component={SearchPage}
         />
 
         <OpenRoute


### PR DESCRIPTION
LTI deeplinking search for canvas integration was prematurely pushed into master and subsequently to production environments. This hotfix reverts the frontend react router to show the previously existing deeplinking views (prototype project browsing)