### PR TITLE
aXe Issue: removing outline on focus makes keyboard navigation impossible

### DIFF
--- a/src/components/Header/style.scss
+++ b/src/components/Header/style.scss
@@ -2,7 +2,7 @@
   .dropdown-toggle {
     background: transparent !important;
     border: none !important;
-    outline: none !important;
+    outline: 2px green solid;
     box-shadow: none !important;
 
     &:after {


### PR DESCRIPTION
This is meant more for guidance as you probably don't want a green outline.

When browsing with a keyboard (tab-tab-tab), the user needs to see where they are focused. Removing the outline makes this close to impossible for keyboard users.

https://www.a11yproject.com/posts/2013-01-25-never-remove-css-outlines/

https://betterprogramming.pub/a11y-never-remove-the-outlines-ee4efc7a9968