### PR TITLE
Invalid domain on google login fixed

### DIFF
--- a/src/containers/Auth/LoginPage.js
+++ b/src/containers/Auth/LoginPage.js
@@ -79,7 +79,12 @@ class LoginPage extends React.Component {
 
   onGoogleLoginSuccess = (response) => {
     const { googleLogin } = this.props;
-    googleLogin(response);
+    const result = googleLogin(response);
+    result.catch((err) => {
+      this.setState({
+        error: getErrors(err),
+      });
+    });
   };
 
   onGoogleLoginFailure = (response) => {


### PR DESCRIPTION
Previously when you try to login through google from an organization you are not a part of, you don't get any error of invalid domain. Added error handling code for google login invalid domain error