### PR TITLE
Independent Activities card: edit dropdown

### DIFF
--- a/src/utils/AddVideoCard/addvideocard.js
+++ b/src/utils/AddVideoCard/addvideocard.js
@@ -185,19 +185,29 @@ const AddVideoCard = ({
                 </OverlayTrigger>
               )
             ) : (
-              <DropDownEdit
-                data={data}
-                iconColor="white"
-                activities={activities}
-                isActivityCard={isActivityCard}
-                setModalShow={setModalShow}
-                setCurrentActivity={setCurrentActivity}
-                setOpenVideo={setOpenVideo}
-                setScreenStatus={setScreenStatus}
-                permission={permission}
-                handleShow={handleShow}
-                setSelectedActivityId={setSelectedActivityId}
-              />
+              <>
+                {(
+                  !isActivityCard
+                  || (
+                    isActivityCard
+                    && permission?.['Independent Activity']?.includes('independent-activity:edit-author')
+                  )
+                ) && (
+                  <DropDownEdit
+                    data={data}
+                    iconColor="white"
+                    activities={activities}
+                    isActivityCard={isActivityCard}
+                    setModalShow={setModalShow}
+                    setCurrentActivity={setCurrentActivity}
+                    setOpenVideo={setOpenVideo}
+                    setScreenStatus={setScreenStatus}
+                    permission={permission}
+                    handleShow={handleShow}
+                    setSelectedActivityId={setSelectedActivityId}
+                  />
+                )}
+              </>
             )}
           </div>
           <div onClick={() => openEditor()} className="addvideo-card-title">


### PR DESCRIPTION
Now hiding edit dropdown menu for independent activities when the user has no author/edit permission